### PR TITLE
Replace `cp` with `install` to also create destination folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,10 @@ riptest: ${OFILES}
 
 install: ${OBJ}
 	strip ripmime
-	cp ripmime ${LOCATION}/bin/
-	cp ripmime.1  ${LOCATION}/man/man1
+	install -d ${LOCATION}/bin/
+	install -m 755 ripmime ${LOCATION}/bin/
+	install -d ${LOCATION}/man/
+	install -m 644 ripmime.1  ${LOCATION}/man/man1
 
 ffget_test: ffget_mmap_test.c ffget_mmap.[ch] logger.o ffget_mmap.o
 	${CC} ${CFLAGS} ffget_mmap_test.c logger.o ffget_mmap.o -o ffgt


### PR DESCRIPTION
Hello and thanks for ripMIME! I'm packaging this program for [Guix](guix.gnu.org/), and I'm being advised that best practice for the install target in a Makefile is to use `install` rather than `cp` to copy files, so that the same utility also creates destination folders. If you're willing to merge this, it simplifies the package configuration for Guix and catches errors for other users.

Thanks and cheers!